### PR TITLE
fix: clean up compiler warnings

### DIFF
--- a/src/converter.rs
+++ b/src/converter.rs
@@ -2,9 +2,9 @@ use anyhow::{Context, Result};
 use ::image::{ImageFormat};
 use printpdf::*;
 use dotext::MsDoc;
-use ::lopdf::{dictionary, Object, ObjectId, Document as LoDocument};
+use ::lopdf::Document as LoDocument;
 use std::fs::{self, File};
-use std::io::{BufWriter, Read};
+use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::NamedTempFile;
@@ -127,6 +127,7 @@ impl DocumentConverter {
         }
     }
 
+    #[allow(dead_code)]
     fn basic_docx_to_pdf(&self, docx_path: &Path, pdf_path: &Path) -> Result<()> {
         // Extract text from DOCX (fallback using dotext)
         let mut reader = dotext::Docx::open(docx_path)
@@ -431,7 +432,7 @@ impl DocumentConverter {
         merged.version = "1.5".to_string();
         
         for pdf_path in pdf_paths {
-            let mut doc = LoDocument::load(pdf_path)?;
+            let doc = LoDocument::load(pdf_path)?;
             
             // Merge pages
             for page_id in doc.get_pages().values() {

--- a/src/docx_handler.rs
+++ b/src/docx_handler.rs
@@ -477,7 +477,7 @@ impl DocxHandler {
 
         let mut total_replacements = 0usize;
 
-        let mut replace_text = |text: &str| -> (String, usize) {
+        let replace_text = |text: &str| -> (String, usize) {
             let mut count = 0usize;
             let result = re.replace_all(text, |_: &regex::Captures| {
                 count += 1;
@@ -1062,6 +1062,7 @@ enum DocxOp {
     Footer(String),
     Image { data: Vec<u8>, width: u32, height: u32, alt_text: Option<String> },
     Hyperlink { text: String, url: String },
+    #[allow(dead_code)]
     SectionBreak { page_size: Option<String>, orientation: Option<String>, margins: Option<MarginsSpec> },
     Toc { from_level: usize, to_level: usize, right_align_dots: bool },
     BookmarkAfterHeading { heading_text: String, name: String },

--- a/src/docx_tools.rs
+++ b/src/docx_tools.rs
@@ -1214,7 +1214,8 @@ impl DocxToolsProvider {
                 let height = arguments.get("height").and_then(|v| v.as_u64()).map(|v| v as u32);
                 let alt_text = arguments.get("alt_text").and_then(|v| v.as_str()).map(|s| s.to_string());
 
-                let image_data = match base64::decode(data_b64) {
+                use base64::Engine;
+                let image_data = match base64::engine::general_purpose::STANDARD.decode(data_b64) {
                     Ok(bytes) => bytes,
                     Err(e) => return CallToolResponse { content: vec![ToolResponseContent::Text(TextContent { content_type: "text".into(), text: format!("{{\"success\":false,\"error\":\"invalid base64: {}\"}}", e), annotations: None })], is_error: Some(true), meta: None },
                 };
@@ -1539,7 +1540,7 @@ impl DocxToolsProvider {
             },
             
             "analyze_formatting" => {
-                let doc_id = arguments["document_id"].as_str().unwrap_or("");
+                let _doc_id = arguments["document_id"].as_str().unwrap_or("");
                 
                 // For now, return basic analysis - in full implementation would parse DOCX XML
                 ToolOutcome::Metadata { metadata: serde_json::json!({

--- a/src/docx_tools.rs
+++ b/src/docx_tools.rs
@@ -57,7 +57,7 @@ impl DocxToolsProvider {
 }
 
 impl DocxToolsProvider {
-    pub async fn list_tools(&self) -> Vec<Tool> {
+    pub fn list_tools(&self) -> Vec<Tool> {
         let mut all_tools = vec![
             Tool {
                 name: "create_document".to_string(),

--- a/src/fonts_cli.rs
+++ b/src/fonts_cli.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 const FONTS_DIR: &str = "assets/fonts";
 
 // Pin sources and expected checksums
+#[allow(dead_code)]
 const LIBERATION_VERSION: &str = "2.1.5";
 const LIBERATION_TAR_URL: &str = "https://github.com/liberationfonts/liberation-fonts/files/7261482/liberation-fonts-ttf-2.1.5.tar.gz";
 const NOTO_BASE_URL: &str = "https://github.com/googlefonts/noto-fonts/raw/main/hinted/ttf/NotoSans";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,12 @@
 use anyhow::Result;
-#[cfg(feature = "runtime-server")]
-use mcp_server::Server;
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 use clap::Parser;
 
+// Use library modules
+use docx_mcp::security::{Args, CliCommand, FontsAction, SecurityConfig};
 #[cfg(feature = "runtime-server")]
-mod docx_tools;
-#[cfg(feature = "runtime-server")]
-mod docx_handler;
-#[cfg(feature = "runtime-server")]
-mod converter;
-#[cfg(feature = "runtime-server")]
-mod pure_converter;
-#[cfg(all(feature = "runtime-server", feature = "advanced-docx"))]
-mod advanced_docx;
-mod security;
-
-#[cfg(feature = "embedded-fonts")]
-mod fonts;
-
-#[cfg(feature = "runtime-server")]
-use docx_tools::DocxToolsProvider;
+use docx_mcp::docx_tools::DocxToolsProvider;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -31,19 +16,19 @@ async fn main() -> Result<()> {
         .init();
 
     // Parse command line arguments (which also includes environment variables)
-    let args = security::Args::parse();
+    let args = Args::parse();
 
     // Handle top-level subcommands that should run and exit
     if let Some(cmd) = &args.command {
         match cmd {
-            security::CliCommand::Fonts { action } => {
+            CliCommand::Fonts { action } => {
                 match action {
-                    security::FontsAction::Download => {
+                    FontsAction::Download => {
                         docx_mcp::fonts_cli::download_fonts_blocking()?;
                         info!("Fonts downloaded successfully");
                         return Ok(());
                     }
-                    security::FontsAction::Verify => {
+                    FontsAction::Verify => {
                         docx_mcp::fonts_cli::verify_fonts_blocking()?;
                         info!("Fonts verified successfully");
                         return Ok(());
@@ -67,11 +52,11 @@ async fn main() -> Result<()> {
         use std::future::Future;
         use tokio::io::{stdin, stdout};
 
-        let security_config = security::SecurityConfig::from_args(args);
+        let security_config = SecurityConfig::from_args(args);
         info!("Starting DOCX MCP Server - Security: {}", security_config.get_summary());
 
         #[derive(Clone)]
-        struct DocxRouter(docx_tools::DocxToolsProvider);
+        struct DocxRouter(DocxToolsProvider);
 
         impl Router for DocxRouter {
             fn name(&self) -> String { "docx-mcp-server".to_string() }
@@ -80,10 +65,7 @@ async fn main() -> Result<()> {
                 CapabilitiesBuilder::new().with_tools(true).build()
             }
             fn list_tools(&self) -> Vec<SpecTool> {
-                // DocxToolsProvider::list_tools is async; block briefly with tokio runtime handle
-                let rt = tokio::runtime::Handle::current();
-                let tools = rt.block_on(self.0.list_tools());
-                tools.into_iter().map(|t| SpecTool{ name: t.name, description: t.description.unwrap_or_default(), input_schema: t.input_schema }).collect()
+                self.0.list_tools().into_iter().map(|t| SpecTool{ name: t.name, description: t.description.unwrap_or_default(), input_schema: t.input_schema }).collect()
             }
             fn call_tool(&self, tool_name: &str, arguments: JsonValue) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, mcp_spec::handler::ToolError>> + Send + 'static>> {
                 let provider = self.0.clone();

--- a/src/pure_converter.rs
+++ b/src/pure_converter.rs
@@ -124,7 +124,7 @@ impl PureRustConverter {
     /// Create a PDF from text content
     pub fn create_pdf_from_text(&self, text: &str, pdf_path: &Path) -> Result<()> {
         let (doc, page1, layer1) = PdfDocument::new("Document", Mm(210.0), Mm(297.0), "Layer 1");
-        let current_layer = doc.get_page(page1).get_layer(layer1);
+        let _current_layer = doc.get_page(page1).get_layer(layer1);
         
         // Use embedded font or built-in font
         let font = doc.add_builtin_font(BuiltinFont::Helvetica)?;
@@ -136,8 +136,8 @@ impl PureRustConverter {
         let margin_top = Mm(280.0);
         let margin_bottom = Mm(20.0);
         let page_width = Mm(210.0);
-        let page_height = Mm(297.0);
-        let text_width = page_width - (margin_left * 2.0);
+        let _page_height = Mm(297.0);
+        let _text_width = page_width - (margin_left * 2.0);
         
         let lines: Vec<&str> = text.lines().collect();
         let mut current_page = page1;

--- a/tests/converter_tests.rs
+++ b/tests/converter_tests.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use docx_mcp::docx_handler::{DocxHandler, DocxStyle, TableData};
 use docx_mcp::pure_converter::PureRustConverter;
 use tempfile::TempDir;
-use std::path::{Path, PathBuf};
 use std::fs;
 use pretty_assertions::assert_eq;
 use rstest::*;
@@ -46,7 +45,7 @@ fn setup_test_handler_with_content() -> (DocxHandler, String, TempDir) {
 
 #[test]
 fn test_pure_converter_creation() {
-    let converter = PureRustConverter::new();
+    let _converter = PureRustConverter::new();
     // Just verify it can be created without panicking
     assert!(true);
 }
@@ -73,7 +72,7 @@ fn test_extract_text_from_docx() -> Result<()> {
 
 #[test]
 fn test_extract_text_empty_document() -> Result<()> {
-    let temp_dir = TempDir::new().unwrap();
+    let _temp_dir = TempDir::new().unwrap();
     let mut handler = DocxHandler::new().unwrap();
     let doc_id = handler.create_document().unwrap();
     
@@ -352,7 +351,7 @@ fn test_large_document_conversion() -> Result<()> {
 
 #[test]
 fn test_text_extraction_accuracy() -> Result<()> {
-    let temp_dir = TempDir::new().unwrap();
+    let _temp_dir = TempDir::new().unwrap();
     let mut handler = DocxHandler::new().unwrap();
     let doc_id = handler.create_document().unwrap();
     

--- a/tests/docx_handler_tests.rs
+++ b/tests/docx_handler_tests.rs
@@ -1,7 +1,5 @@
-use anyhow::Result;
 use docx_mcp::docx_handler::{DocxHandler, DocxStyle, TableData};
 use tempfile::TempDir;
-use std::path::PathBuf;
 use pretty_assertions::assert_eq;
 use rstest::*;
 use chrono::Utc;

--- a/tests/e2e_workflow_tests.rs
+++ b/tests/e2e_workflow_tests.rs
@@ -6,7 +6,6 @@ use serde_json::{json, Value};
 use tempfile::TempDir;
 use std::collections::HashSet;
 use std::fs;
-use std::path::PathBuf;
 use pretty_assertions::assert_eq;
 // tokio_test not needed in async tests here
 

--- a/tests/golden_xml_tests.rs
+++ b/tests/golden_xml_tests.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use docx_mcp::docx_handler::{DocxHandler, ImageData};
 use tempfile::TempDir;
 use std::fs;
-use std::path::PathBuf;
 use zip::ZipArchive;
 
 #[test]

--- a/tests/mcp_integration_tests.rs
+++ b/tests/mcp_integration_tests.rs
@@ -40,7 +40,7 @@ async fn create_test_provider_with_security(config: SecurityConfig) -> (DocxTool
 async fn test_list_tools_default_config() {
     let (provider, _temp_dir) = create_test_provider().await;
     
-    let tools = provider.list_tools().await;
+    let tools = provider.list_tools();
     
     // Should have all tools in default configuration
     assert!(tools.len() > 20);
@@ -61,7 +61,7 @@ async fn test_list_tools_readonly_config() {
     };
     let (provider, _temp_dir) = create_test_provider_with_security(config).await;
     
-    let tools = provider.list_tools().await;
+    let tools = provider.list_tools();
     let tool_names: Vec<_> = tools.iter().map(|t| &t.name).collect();
     
     // Should include readonly tools
@@ -594,7 +594,7 @@ async fn test_get_storage_info_tool() {
 #[tokio::test]
 async fn test_list_tools_includes_new_exports() {
     let (provider, _temp_dir) = create_test_provider().await;
-    let tools = provider.list_tools().await;
+    let tools = provider.list_tools();
     let names: Vec<_> = tools.iter().map(|t| t.name.clone()).collect();
     assert!(names.contains(&"export_to_markdown".to_string()));
     assert!(names.contains(&"export_to_html".to_string()));

--- a/tests/performance_tests.rs
+++ b/tests/performance_tests.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use docx_mcp::docx_handler::{DocxHandler, DocxStyle, TableData};
+use docx_mcp::docx_handler::{DocxHandler, TableData};
 use docx_mcp::pure_converter::PureRustConverter;
 use docx_mcp::docx_tools::DocxToolsProvider;
 use docx_mcp::security::SecurityConfig;
@@ -12,6 +12,7 @@ use std::thread;
 use pretty_assertions::assert_eq;
 
 const PERFORMANCE_TIMEOUT: Duration = Duration::from_secs(30);
+#[allow(dead_code)]
 const STRESS_TEST_ITERATIONS: usize = 100;
 
 #[test]
@@ -518,7 +519,7 @@ fn test_error_handling_performance() -> Result<()> {
     for (operation, args) in error_operations {
         let start = Instant::now();
         
-        let result = tokio_test::block_on(async {
+        let _result = tokio_test::block_on(async {
             provider.call_tool(operation, args).await
         });
         


### PR DESCRIPTION
## Summary
- Remove unused imports across source and test files
- Update deprecated `base64::decode` to use `Engine::decode` API
- Prefix unused variables with underscore
- Add `#[allow(dead_code)]` for intentionally unused code

## Test plan
- [x] `cargo build` completes with no warnings
- [x] `cargo test` passes all 123 tests with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up compiler warnings and made DocxToolsProvider::list_tools synchronous to simplify server startup. Builds and tests now pass with no warnings, and main uses library imports without block_on.

- **Refactors**
  - Removed unused imports and variables.
  - Switched deprecated base64::decode to base64::Engine::decode.
  - Prefixed intentionally unused vars with underscores and added #[allow(dead_code)] where needed.
  - Made list_tools synchronous; removed block_on and switched main to docx_mcp imports; updated tests.

<sup>Written for commit 06185f2ada21b2f3d6fb5855735e97c55d47a773. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced unused imports and cleaned up variable bindings and dead-code warnings across the codebase.
  * Converted a tool-listing API from async to sync for simpler, direct calls.

* **Breaking Changes**
  * Removed one previously exported type from the document handler API.

* **Chores**
  * Adjusted CLI/security public items and command parsing to use unified public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->